### PR TITLE
WIP: Fix compatibility with julia v0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - 0.5
+  - 0.6
   - nightly
 addons:
   apt_packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ addons:
 notifications:
   email: false
 # uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("cddlib"); Pkg.test("cddlib"; coverage=true)'
+script:
+ - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+ - julia -e 'Pkg.init(); Pkg.add("GeometryTypes"); Pkg.checkout("GeometryTypes")'
+ - julia -e 'Pkg.clone(pwd()); Pkg.build("cddlib"); Pkg.test("cddlib"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("CDDLib")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ notifications:
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
  - julia -e 'Pkg.init(); Pkg.add("GeometryTypes"); Pkg.checkout("GeometryTypes")'
- - julia -e 'Pkg.clone(pwd()); Pkg.build("cddlib"); Pkg.test("cddlib"; coverage=true)'
+ - julia -e 'Pkg.clone(pwd()); Pkg.build("CDDLib"); Pkg.test("CDDLib"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("CDDLib")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 addons:
@@ -16,6 +15,7 @@ notifications:
 script:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
  - julia -e 'Pkg.init(); Pkg.add("GeometryTypes"); Pkg.checkout("GeometryTypes")'
+  - julia -e 'Pkg.clone("https://github.com/rdeits/Polyhedra.jl"); Pkg.checkout("Polyhedra", "fix-0.6"); Pkg.build("Polyhedra")'
  - julia -e 'Pkg.clone(pwd()); Pkg.build("CDDLib"); Pkg.test("CDDLib"; coverage=true)'
 after_success:
   # push coverage results to Coveralls

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,6 @@ julia 0.5
 BinDeps
 MathProgBase
 Polyhedra 0.1.5 0.2
+Compat 0.17
 @windows WinRPM
 @osx Homebrew

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6-
 BinDeps
 MathProgBase
 Polyhedra 0.1.5 0.2

--- a/src/CDDLib.jl
+++ b/src/CDDLib.jl
@@ -3,6 +3,7 @@ __precompile__()
 module CDDLib
 
 using BinDeps
+using Compat: @compat
 importall Polyhedra
 
 if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))

--- a/src/CDDLib.jl
+++ b/src/CDDLib.jl
@@ -3,7 +3,6 @@ __precompile__()
 module CDDLib
 
 using BinDeps
-using Compat: @compat
 importall Polyhedra
 
 if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))

--- a/src/cddtypes.jl
+++ b/src/cddtypes.jl
@@ -1,53 +1,53 @@
-typealias Cdd_boolean Cint
+const Cdd_boolean = Cint
 
-typealias Cdd_rowrange Clong
-typealias Cdd_colrange Clong
-typealias Cdd_bigrange Clong
+const Cdd_rowrange = Clong
+const Cdd_colrange = Clong
+const Cdd_bigrange = Clong
 
-typealias Cset_type Ptr{Culong}
-typealias Cdd_rowset Cset_type
-typealias Cdd_colset Cset_type
+const Cset_type = Ptr{Culong}
+const Cdd_rowset = Cset_type
+const Cdd_colset = Cset_type
 
-typealias Cdd_rowindex Ptr{Clong}
-typealias Cdd_rowflag Ptr{Cint}
-typealias Cdd_colindex Ptr{Clong}
+const Cdd_rowindex = Ptr{Clong}
+const Cdd_rowflag = Ptr{Cint}
+const Cdd_colindex = Ptr{Clong}
 
-typealias Cdd_Amatrix{T} Ptr{Ptr{T}}
-typealias Cdd_Arow{T} Ptr{T}
+@compat Cdd_Amatrix{T} = Ptr{Ptr{T}}
+@compat Cdd_Arow{T} = Ptr{T}
 
-typealias Cdd_SetVector Ptr{Cset_type}
-typealias Cdd_Bmatrix{T} Ptr{Ptr{T}}
-typealias Cdd_Aincidence Ptr{Cset_type}
+const Cdd_SetVector = Ptr{Cset_type}
+@compat Cdd_Bmatrix{T} = Ptr{Ptr{T}}
+const Cdd_Aincidence = Ptr{Cset_type}
 
-bitstype 2040 Cdd_DataFileType # char[255]
+@compat primitive type Cdd_DataFileType 2040 end # char[255]
 
-typealias Cdd_NumberType Cint
+const Cdd_NumberType = Cint
 # dd_Unknown=0, dd_Real, dd_Rational, dd_Integer
 const dd_Unknown  = 0
 const dd_Real     = 1
 const dd_Rational = 2
 const dd_Integer  = 3
 
-typealias Cdd_RepresentationType Cint
+const Cdd_RepresentationType = Cint
 # dd_Unspecified=0, dd_Inequality, dd_Generator
 const dd_Unspecified = 0
 const dd_Inequality  = 1
 const dd_Generator   = 2
 
-typealias Cdd_ConversionType Cint
+const Cdd_ConversionType = Cint
 # dd_IneToGen, dd_GenToIne, dd_LPMax, dd_LPMin, dd_InteriorFind
 
-typealias Cdd_IncidenceOutputType Cint
+const Cdd_IncidenceOutputType = Cint
 # dd_IncOff=0, dd_IncCardinality, dd_IncSet
 
-typealias Cdd_AdjacencyOutputType Cint
+const Cdd_AdjacencyOutputType = Cint
 # dd_AdjOff=0, dd_AdjacencyList,  dd_AdjacencyDegree
 
-typealias Cdd_FileInputModeType Cint
+const Cdd_FileInputModeType = Cint
 # dd_Auto, dd_SemiAuto, dd_Manual
 # Auto if a input filename is specified by command arguments
 
-typealias Cdd_ErrorType Cint
+const Cdd_ErrorType = Cint
 # dd_DimensionTooLarge, dd_ImproperInputFormat,
 # dd_NegativeMatrixSize, dd_EmptyVrepresentation, dd_EmptyHrepresentation, dd_EmptyRepresentation,
 # dd_IFileNotFound, dd_OFileNotOpen, dd_NoLPObjective, dd_NoRealNumberSupport,
@@ -56,23 +56,23 @@ typealias Cdd_ErrorType Cint
 # dd_LPCycling, dd_NumericallyInconsistent,
 # dd_NoError
 
-typealias Cdd_CompStatusType Cint
+const Cdd_CompStatusType = Cint
 # dd_InProgress, dd_AllFound, dd_RegionEmpty
 
 # LP types
 
-typealias Cdd_LPObjectiveType Cint
+const Cdd_LPObjectiveType = Cint
 # dd_LPnone=0, dd_LPmax, dd_LPmin
 const dd_LPnone = Cint(0)
 const dd_LPmax  = Cint(1)
 const dd_LPmin  = Cint(2)
 
-typealias Cdd_LPSolverType Cint
+const Cdd_LPSolverType = Cint
 # dd_CrissCross, dd_DualSimplex
 const dd_CrissCross  = Cint(0)
 const dd_DualSimplex = Cint(1)
 
-typealias Cdd_LPStatusType Cint
+const Cdd_LPStatusType = Cint
 # dd_LPSundecided, dd_Optimal, dd_Inconsistent, dd_DualInconsistent,
 # dd_StrucInconsistent, dd_StrucDualInconsistent,
 # dd_Unbounded, dd_DualUnbounded
@@ -85,4 +85,4 @@ const dd_StrucDualInconsistent = Cint(5)
 const dd_Unbounded             = Cint(6)
 const dd_DualUnbounded         = Cint(7)
 
-typealias Ctime_t Clong # FIXME Cint in some systems ?
+const Ctime_t = Clong # FIXME Cint in some systems ?

--- a/src/cddtypes.jl
+++ b/src/cddtypes.jl
@@ -12,14 +12,14 @@ const Cdd_rowindex = Ptr{Clong}
 const Cdd_rowflag = Ptr{Cint}
 const Cdd_colindex = Ptr{Clong}
 
-@compat Cdd_Amatrix{T} = Ptr{Ptr{T}}
-@compat Cdd_Arow{T} = Ptr{T}
+const Cdd_Amatrix{T} = Ptr{Ptr{T}}
+const Cdd_Arow{T} = Ptr{T}
 
 const Cdd_SetVector = Ptr{Cset_type}
-@compat Cdd_Bmatrix{T} = Ptr{Ptr{T}}
+const Cdd_Bmatrix{T} = Ptr{Ptr{T}}
 const Cdd_Aincidence = Ptr{Cset_type}
 
-@compat primitive type Cdd_DataFileType 2040 end # char[255]
+primitive type Cdd_DataFileType 2040 end # char[255]
 
 const Cdd_NumberType = Cint
 # dd_Unknown=0, dd_Real, dd_Rational, dd_Integer

--- a/src/lp.jl
+++ b/src/lp.jl
@@ -43,7 +43,7 @@ end
 type CDDLPSolution{T<:MyType}
   sol::Ptr{Cdd_LPSolutionData{T}}
 
-  function (::Type{CDDLPSolution{T}}){T <: MyType}(sol::Ptr{Cdd_LPSolutionData{T}})
+  function CDDLPSolution{T}(sol::Ptr{Cdd_LPSolutionData{T}}) where {T <: MyType}
     s = new{T}(sol)
     finalizer(s, myfree)
     s
@@ -190,7 +190,7 @@ end
 type CDDLP{T<:MyType}
   lp::Ptr{Cdd_LPData{T}}
 
-  function (::Type{CDDLP{T}}){T <: MyType}(lp::Ptr{Cdd_LPData{T}})
+  function CDDLP{T}(lp::Ptr{Cdd_LPData{T}}) where {T <: MyType}
     l = new{T}(lp)
     finalizer(l, myfree)
     l

--- a/src/lp.jl
+++ b/src/lp.jl
@@ -43,8 +43,8 @@ end
 type CDDLPSolution{T<:MyType}
   sol::Ptr{Cdd_LPSolutionData{T}}
 
-  function CDDLPSolution(sol::Ptr{Cdd_LPSolutionData{T}})
-    s = new(sol)
+  function (::Type{CDDLPSolution{T}}){T <: MyType}(sol::Ptr{Cdd_LPSolutionData{T}})
+    s = new{T}(sol)
     finalizer(s, myfree)
     s
   end
@@ -190,8 +190,8 @@ end
 type CDDLP{T<:MyType}
   lp::Ptr{Cdd_LPData{T}}
 
-  function CDDLP(lp::Ptr{Cdd_LPData{T}})
-    l = new(lp)
+  function (::Type{CDDLP{T}}){T <: MyType}(lp::Ptr{Cdd_LPData{T}})
+    l = new{T}(lp)
     finalizer(l, myfree)
     l
   end

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -96,7 +96,7 @@ end
 type CDDInequalityMatrix{N, T <: PolyType, S <: MyType} <: HRepresentation{N, T}
   matrix::Ptr{Cdd_MatrixData{S}}
 
-  function (::Type{CDDInequalityMatrix{N, T, S}}){N, T <: PolyType, S <: MyType}(matrix::Ptr{Cdd_MatrixData{S}})
+  function CDDInequalityMatrix{N, T, S}(matrix::Ptr{Cdd_MatrixData{S}}) where {N, T <: PolyType, S <: MyType}
     @assert polytype(S) == T
     m = new{N, T, S}(matrix)
     finalizer(m, myfree)
@@ -112,7 +112,7 @@ decomposedfast(ine::CDDInequalityMatrix) = false
 type CDDGeneratorMatrix{N, T <: PolyType, S <: MyType} <: VRepresentation{N, T}
   matrix::Ptr{Cdd_MatrixData{S}}
 
-  function (::Type{CDDGeneratorMatrix{N, T, S}}){N, T <: PolyType, S <: MyType}(matrix::Ptr{Cdd_MatrixData{S}})
+  function CDDGeneratorMatrix{N, T, S}(matrix::Ptr{Cdd_MatrixData{S}}) where {N, T <: PolyType, S <: MyType}
     @assert polytype(S) == T
     m = new{N, T, S}(matrix)
     finalizer(m, myfree)
@@ -125,7 +125,7 @@ changefulldim{N, T, S}(::Type{CDDGeneratorMatrix{N, T, S}}, NewN) = CDDGenerator
 changeboth{N, T, S, NewT}(::Type{CDDGeneratorMatrix{N, T, S}}, NewN, ::Type{NewT}) = CDDGeneratorMatrix{NewN, NewT, mytype(NewT)}
 decomposedfast(ine::CDDGeneratorMatrix) = false
 
-@compat CDDMatrix{N, T, S} = Union{CDDInequalityMatrix{N, T, S}, CDDGeneratorMatrix{N, T, S}}
+const CDDMatrix{N, T, S} = Union{CDDInequalityMatrix{N, T, S}, CDDGeneratorMatrix{N, T, S}}
 (::Type{CDDMatrix{N, T}}){N, T}(rep) = CDDMatrix{N, T, mytype(T)}(rep)
 
 function linset(matrix::CDDMatrix)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -96,9 +96,9 @@ end
 type CDDInequalityMatrix{N, T <: PolyType, S <: MyType} <: HRepresentation{N, T}
   matrix::Ptr{Cdd_MatrixData{S}}
 
-  function CDDInequalityMatrix{S}(matrix::Ptr{Cdd_MatrixData{S}})
+  function (::Type{CDDInequalityMatrix{N, T, S}}){N, T <: PolyType, S <: MyType}(matrix::Ptr{Cdd_MatrixData{S}})
     @assert polytype(S) == T
-    m = new(matrix)
+    m = new{N, T, S}(matrix)
     finalizer(m, myfree)
     m
   end
@@ -112,9 +112,9 @@ decomposedfast(ine::CDDInequalityMatrix) = false
 type CDDGeneratorMatrix{N, T <: PolyType, S <: MyType} <: VRepresentation{N, T}
   matrix::Ptr{Cdd_MatrixData{S}}
 
-  function CDDGeneratorMatrix{S}(matrix::Ptr{Cdd_MatrixData{S}})
+  function (::Type{CDDGeneratorMatrix{N, T, S}}){N, T <: PolyType, S <: MyType}(matrix::Ptr{Cdd_MatrixData{S}})
     @assert polytype(S) == T
-    m = new(matrix)
+    m = new{N, T, S}(matrix)
     finalizer(m, myfree)
     m
   end
@@ -125,7 +125,7 @@ changefulldim{N, T, S}(::Type{CDDGeneratorMatrix{N, T, S}}, NewN) = CDDGenerator
 changeboth{N, T, S, NewT}(::Type{CDDGeneratorMatrix{N, T, S}}, NewN, ::Type{NewT}) = CDDGeneratorMatrix{NewN, NewT, mytype(NewT)}
 decomposedfast(ine::CDDGeneratorMatrix) = false
 
-typealias CDDMatrix{N, T, S} Union{CDDInequalityMatrix{N, T, S}, CDDGeneratorMatrix{N, T, S}}
+@compat CDDMatrix{N, T, S} = Union{CDDInequalityMatrix{N, T, S}, CDDGeneratorMatrix{N, T, S}}
 (::Type{CDDMatrix{N, T}}){N, T}(rep) = CDDMatrix{N, T, mytype(T)}(rep)
 
 function linset(matrix::CDDMatrix)

--- a/src/mytype.jl
+++ b/src/mytype.jl
@@ -137,8 +137,8 @@ promote_rule{T<:Integer}(::Type{GMPRational}, ::Type{T}) = GMPRational
 
 ==(x::GMPRational, y::GMPRational) = Rational(x) == Rational(y)
 
-typealias PolyType Union{Rational{BigInt}, Cdouble}
-typealias MyType Union{GMPRational, Cdouble}
+const PolyType = Union{Rational{BigInt}, Cdouble}
+const MyType = Union{GMPRational, Cdouble}
 
 mytype(::Type{Cdouble}) = Cdouble
 mytype(::Type{Rational{BigInt}}) = GMPRational

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -68,7 +68,7 @@ function dd_redundant(matrix::Ptr{Cdd_MatrixData{GMPRational}}, i::Cdd_rowrange,
   found = (@dd_ccall Redundant Cdd_boolean (Ptr{Cdd_MatrixData{GMPRational}}, Cdd_rowrange, Ptr{GMPRational}, Ref{Cdd_ErrorType}) matrix i certificateGMPRat err)
   myerror(err[])
   certificate = Array{Rational{BigInt}}(certificateGMPRat)
-  myfree(certificateGMPRat)
+  # myfree(certificateGMPRat)  # disabled due to https://github.com/JuliaPolyhedra/CDDLib.jl/issues/13
   (found, certificate)
 end
 function redundant(matrix::CDDMatrix, i::Integer)
@@ -117,7 +117,7 @@ function dd_sredundant(matrix::Ptr{Cdd_MatrixData{GMPRational}}, i::Cdd_rowrange
   found = (@dd_ccall SRedundant Cdd_boolean (Ptr{Cdd_MatrixData{GMPRational}}, Cdd_rowrange, Ptr{GMPRational}, Ref{Cdd_ErrorType}) matrix i certificateGMPRat err)
   myerror(err[])
   certificate = Array{Rational{BigInt}}(certificateGMPRat)
-  myfree(certificateGMPRat)
+  # myfree(certificateGMPRat)  # disabled due to https://github.com/JuliaPolyhedra/CDDLib.jl/issues/13
   (found, certificate)
 end
 function sredundant(matrix::CDDMatrix, i::Integer)

--- a/src/polyhedra.jl
+++ b/src/polyhedra.jl
@@ -64,7 +64,7 @@ type CDDPolyhedra{N, T<:PolyType, S}
   poly::Ptr{Cdd_PolyhedraData{S}}
   inequality::Bool # The input type is inequality
 
-  function (::Type{CDDPolyhedra{N, T, S}}){N, T <: PolyType, S}(matrix::CDDMatrix{N, T})
+  function CDDPolyhedra{N, T, S}(matrix::CDDMatrix{N, T}) where {N, T <: PolyType, S}
     polyptr = dd_matrix2poly(matrix.matrix)
     poly = new{N, T, S}(polyptr, isaninequalityrepresentation(matrix))
     finalizer(poly, myfree)

--- a/src/polyhedra.jl
+++ b/src/polyhedra.jl
@@ -64,9 +64,9 @@ type CDDPolyhedra{N, T<:PolyType, S}
   poly::Ptr{Cdd_PolyhedraData{S}}
   inequality::Bool # The input type is inequality
 
-  function CDDPolyhedra(matrix::CDDMatrix{N, T})
+  function (::Type{CDDPolyhedra{N, T, S}}){N, T <: PolyType, S}(matrix::CDDMatrix{N, T})
     polyptr = dd_matrix2poly(matrix.matrix)
-    poly = new(polyptr, isaninequalityrepresentation(matrix))
+    poly = new{N, T, S}(polyptr, isaninequalityrepresentation(matrix))
     finalizer(poly, myfree)
     poly
   end

--- a/src/polyhedron.jl
+++ b/src/polyhedron.jl
@@ -21,11 +21,11 @@ type CDDPolyhedron{N, T<:PolyType} <: Polyhedron{N, T}
   noredundantinequality::Bool
   noredundantgenerator::Bool
 
-  function CDDPolyhedron(ine::CDDInequalityMatrix)
-    new(ine, nothing, nothing, false, false, false, false)
+  function (::Type{CDDPolyhedron{N, T}}){N, T <: PolyType}(ine::CDDInequalityMatrix)
+    new{N, T}(ine, nothing, nothing, false, false, false, false)
   end
-  function CDDPolyhedron(ext::CDDGeneratorMatrix)
-    new(nothing, ext, nothing, false, false, false, false)
+  function (::Type{CDDPolyhedron{N, T}}){N, T <: PolyType}(ext::CDDGeneratorMatrix) 
+    new{N, T}(nothing, ext, nothing, false, false, false, false)
   end
 # function CDDPolyhedron(poly::CDDPolyhedra{T})
 #   new(nothing, nothing, poly)

--- a/src/polyhedron.jl
+++ b/src/polyhedron.jl
@@ -21,10 +21,10 @@ type CDDPolyhedron{N, T<:PolyType} <: Polyhedron{N, T}
   noredundantinequality::Bool
   noredundantgenerator::Bool
 
-  function (::Type{CDDPolyhedron{N, T}}){N, T <: PolyType}(ine::CDDInequalityMatrix)
+  function CDDPolyhedron{N, T}(ine::CDDInequalityMatrix) where {N, T <: PolyType}
     new{N, T}(ine, nothing, nothing, false, false, false, false)
   end
-  function (::Type{CDDPolyhedron{N, T}}){N, T <: PolyType}(ext::CDDGeneratorMatrix) 
+  function CDDPolyhedron{N, T}(ext::CDDGeneratorMatrix) where {N, T <: PolyType}
     new{N, T}(nothing, ext, nothing, false, false, false, false)
   end
 # function CDDPolyhedron(poly::CDDPolyhedra{T})

--- a/test/permutahedron.jl
+++ b/test/permutahedron.jl
@@ -63,8 +63,8 @@ end"
     extf    = SimpleVRepresentation{3, Int}(round(extmf))
     inequality_simpletest(ineout, A, b, ls)
     inequality_simpletest(ineoutf, A, b, ls)
-    generator_simpletest(ext, V, Array(Int, 0, 3))
-    generator_simpletest(extf, V, Array(Int, 0, 3))
+    generator_simpletest(ext, V, Array{Int}(0, 3))
+    generator_simpletest(extf, V, Array{Int}(0, 3))
 
 
     # x1___x4____________1
@@ -115,6 +115,6 @@ end"
     # This does inexact error: WTF why ???
     #extunlift = Representation{3,Int}(copygenerators(polylift))
     #extunliftf = Representation{3,Int}(copygenerators(polyliftf))
-    generator_simpletest(extunlift, V, Array(Int, 0, 3))
-    generator_simpletest(extunliftf, V, Array(Int, 0, 3))
+    generator_simpletest(extunlift, V, Array{Int}(0, 3))
+    generator_simpletest(extunliftf, V, Array{Int}(0, 3))
 end

--- a/test/simplex.jl
+++ b/test/simplex.jl
@@ -98,8 +98,8 @@ generator_simpletest(ext::VRepresentation, V, R = Matrix{eltype(V)}(0, size(V, 2
     Rray = [1 0; 0 1]
     extray = SimpleVRepresentation(Matrix{Int}(0,2), Rray)
     extrayf = SimpleVRepresentation(Matrix{Float64}(0,2), Array{Float64}(Rray))
-    generator_simpletest(extray, Array(Int, 0, 2), Rray)
-    generator_simpletest(extrayf, Array(Int, 0, 2), Rray)
+    generator_simpletest(extray, Array{Int}(0, 2), Rray)
+    generator_simpletest(extrayf, Array{Int}(0, 2), Rray)
     polyray = CDDPolyhedra(extray)
     polyrayf = CDDPolyhedra(extrayf)
     Acut = [1 1]
@@ -116,6 +116,6 @@ generator_simpletest(ext::VRepresentation, V, R = Matrix{eltype(V)}(0, size(V, 2
     inequality_simpletest(ineout5f, [-1 0; 0 -1; Acut], [0; 0; bcut], IntSet([3]))
     generator_simpletest(extout5, V)
     generator_simpletest(extout5f, V)
-    generator_simpletest(extout5, V, Array(Int, 0, 2))
-    generator_simpletest(extout5f, V, Array(Int, 0, 2))
+    generator_simpletest(extout5, V, Array{Int}(0, 2))
+    generator_simpletest(extout5f, V, Array{Int}(0, 2))
 end


### PR DESCRIPTION
Includes scary workaround for #13 

as with https://github.com/JuliaPolyhedra/Polyhedra.jl/pull/24 this bumps the required Julia version up to v0.6 since the newest GeometryTypes and StaticArrays both require v0.6. 