### PR TITLE
require hypothetical future version of Polyhedra

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
-julia 0.6-
+julia 0.6
 BinDeps
 MathProgBase
-Polyhedra 0.1.5 0.2
+Polyhedra 0.2 0.3
 Compat 0.17
 @windows WinRPM
 @osx Homebrew


### PR DESCRIPTION
This won't work until Polyhedra 0.2 is tagged, but I think it's time for a v0.6-compatible minor version of CDDLib too. 