### PR TITLE
PolyhedraToLPQPBridge: Pass arrays with Rational if exact==true

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.7
 BinDeps
 MathProgBase 0.6
-Polyhedra 0.4 0.5
+Polyhedra 0.4.4 0.5
 @windows WinRPM
 @osx Homebrew

--- a/src/mathprogbase.jl
+++ b/src/mathprogbase.jl
@@ -1,3 +1,5 @@
+using SparseArrays
+
 export CDDPolyhedraModel, CDDSolver
 
 mutable struct CDDPolyhedraModel <: Polyhedra.AbstractPolyhedraModel
@@ -29,6 +31,12 @@ end
 function Polyhedra.PolyhedraModel(s::CDDSolver)
     CDDPolyhedraModel(s.solver_type, s.exact, nothing, :Undefined, 0, [], [], [], [])
 end
+
+function Polyhedra.PolyhedraToLPQPBridge(lpm::CDDPolyhedraModel)
+    T = lpm.exact ? Rational{BigInt} : Float64
+    Polyhedra.PolyhedraToLPQPBridge(lpm, sparse(Int[],Int[],T[]), T[], T[], T[], T[], T[], :Min, nothing, nothing)
+end
+
 MPB.LinearQuadraticModel(s::CDDSolver) = Polyhedra.PolyhedraToLPQPBridge(Polyhedra.PolyhedraModel(s))
 
 function MPB.loadproblem!(lpm::CDDPolyhedraModel, rep::HRep, obj, sense)

--- a/test/mathprogbase.jl
+++ b/test/mathprogbase.jl
@@ -20,3 +20,21 @@ linprogsolvertest(CDDSolver(; solver_type=:DualSimplex, exact=true))
 
 linprogsolvertest(CDDSolver(; solver_type=:CrissCross))
 linprogsolvertest(CDDSolver(; solver_type=:CrissCross, exact=true))
+
+# Issue #31
+@testset "CDDSolver: exact solution" begin
+    A = [7//3 1//3]
+    sense = '<'
+    b = 1//2
+    c = [-1//1, 0]
+
+    val = -3//14
+    x = [3//14, 0//1]
+
+    for solver_type in [:DualSimplex, :CrissCross]
+        lp_solver = CDDSolver(solver_type=solver_type, exact=true)
+        sol = MathProgBase.linprog(c, A, '<', b, lp_solver)
+        @test sol.objval == val
+        @test sol.sol == x
+    end
+end


### PR DESCRIPTION
Need JuliaPolyhedra/Polyhedra.jl#141.

Fix #31.

The exact solution obtains:

```jl
using CDDLib
using MathProgBase
lp_solver = CDDSolver(exact=true)
```

```jl
sol = linprog([-1, 0], [7  1], '<', 3//2, lp_solver)
sol.objval
```

```
-3//14
```

```jl
sol = linprog([-1, 0], [7//3  1//3], '<', 1//2, lp_solver)
sol.objval
```

```
-3//14
```

Note that `PolyhedraToLPQPBridge` is now type unstable. Try

```jl
lmp = Polyhedra.PolyhedraModel(lp_solver)
@code_warntype PolyhedraToLPQPBridge(lmp)
```

This is also the case for `MPB.loadproblem!(lpm::CDDPolyhedraModel, rep::HRep, obj, sense)`.