### PR TITLE
Add check_deps() to __init__

### DIFF
--- a/src/CDDLib.jl
+++ b/src/CDDLib.jl
@@ -33,6 +33,7 @@ macro cdd_ccall(f, args...)
 end
 
 function __init__()
+    check_deps()
     @dd_ccall set_global_constants Nothing ()
 end
 


### PR DESCRIPTION
I ran into #36 and this seems to fix it.

The `deps.jl` states:

```
## This file autogenerated by BinaryProvider.write_deps_file().
## Do not edit.
##
## Include this file within your main top-level source, and call
## `check_deps()` from within your module's `__init__()` method
```

So I added this and now things seem to work on my computer. 