### PR TITLE
Run MOI tests for Rational{BigInt}

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -7,21 +7,19 @@ const MOIB = MOI.Bridges
 using Polyhedra
 using CDDLib
 
-@testset "MOI wrapper" begin
-    @testset "coefficient_type $T" for T in [Rational{BigInt}, Float64]
+@testset "MOI wrapper with $T" for T in [Rational{BigInt}, Float64]
+    @testset "coefficient_type" begin
         @test Polyhedra.coefficient_type(CDDLib.Optimizer{T}()) == T
     end
-    optimizer = CDDLib.Optimizer{Float64}()
+    optimizer = CDDLib.Optimizer{T}()
     @testset "SolverName" begin
         @test MOI.get(optimizer, MOI.SolverName()) == "CDD"
     end
-    @testset "Continuous Linear problems with CDDLib.Optimizer" begin
-        cache = MOIU.UniversalFallback(Polyhedra._MOIModel{Float64}())
+    @testset "Continuous Linear problems with CDDLib.Optimizer{$T}" begin
+        cache = MOIU.UniversalFallback(Polyhedra._MOIModel{T}())
         cached = MOIU.CachingOptimizer(cache, optimizer)
-        bridged = MOIB.full_bridge_optimizer(cached, Float64)
-        config = MOIT.TestConfig(duals=false)
-        MOIT.contlineartest(bridged, config,
-                            # linear8a and linear12 will be solved by https://github.com/JuliaOpt/MathOptInterface.jl/pull/702
-                            ["linear8a", "linear12", "partial_start"])
+        bridged = MOIB.full_bridge_optimizer(cached, T)
+        config = MOIT.TestConfig{T}(duals=false)
+        MOIT.contlineartest(bridged, config, ["partial_start"])
     end
 end


### PR DESCRIPTION
Requires https://github.com/JuliaOpt/MathOptInterface.jl/pull/887
Thanks @ericphanson for making it possible to run `contlineartest` for any coefficient type in https://github.com/JuliaOpt/MathOptInterface.jl/pull/855 !
cc @schillic