### PR TITLE
Update README with JuMP information

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 | [![Build Status][build-img]][build-url] | [![DOI][zenodo-img]][zenodo-url] |
 | [![Codecov branch][codecov-img]][codecov-url] | |
 
-CDDLib is a wrapper for [cdd](https://www.inf.ethz.ch/personal/fukudak/cdd_home/). This module can either be used in a "lower level" using the API of cdd or using the higher level interface of [Polyhedra](https://github.com/JuliaPolyhedra/Polyhedra.jl).
-CDDLib also includes the linear programming solver `CDDLib.Optimizer` which can be used by [JuMP](https://github.com/JuliaOpt/JuMP.jl) through [MathOptInterface](https://github.com/JuliaOpt/MathOptInterface.jl).
+CDDLib is a wrapper for [cdd](https://www.inf.ethz.ch/personal/fukudak/cdd_home/). 
 
-Building the package will download binaries of [`cddlib`](https://github.com/cddlib/cddlib)
-that are compiled by [cddlibBuilder](https://github.com/JuliaPolyhedra/cddlibBuilder/).
+This package can either be used in a "lower level" using the API of cdd or using the 
+higher level interface of [Polyhedra](https://github.com/JuliaPolyhedra/Polyhedra.jl).
+
+## Problem description
 
 As written in the [README of cddlib](ftp://ftp.ifor.math.ethz.ch/pub/fukuda/cdd/README.libcdd):
+
 > The C-library  cddlib is a C implementation of the Double Description
 > Method of Motzkin et al. for generating all vertices (i.e. extreme points)
 > and extreme rays of a general convex polyhedron in R^d given by a system
@@ -28,6 +30,35 @@ As written in the [README of cddlib](ftp://ftp.ifor.math.ethz.ch/pub/fukuda/cdd/
 > representation of a polyhedron with cdd.  Also, cdd can solve a linear
 > programming problem, i.e. a problem of maximizing and minimizing
 > a linear function over P.
+
+
+## Installation
+
+```julia
+import Pkg
+Pkg.add("CDDLib")
+```
+
+Building the package will download binaries of [`cddlib`](https://github.com/cddlib/cddlib)
+that are compiled by [cddlibBuilder](https://github.com/JuliaPolyhedra/cddlibBuilder/).
+
+## Use with JuMP
+
+Use `CDDLib.Optimizer{Float64}` to use CDDLib with [JuMP](https://github.com/jump-dev/JuMP.jl):
+```julia
+using JuMP, CDDLib
+model = Model(CDDLib.Optimizer{Float64})
+```
+
+## Use with MathOptInterface
+
+CDD can also solve problems using `Rational{BigInt}` arithmetic. 
+
+Use `CDDLib.Optimizer{Rational{BigInt}}` to use CDDLib with [MathOptInterface](https://github.com/jump-dev/MathOptInterface.jl):
+```julia
+using MathOptInterface, CDDLib
+model = CDDLib.Optimizer{Rational{BigInt}}()
+```
 
 [build-img]: https://github.com/JuliaPolyhedra/CDDLib.jl/workflows/CI/badge.svg?branch=master
 [build-url]: https://github.com/JuliaPolyhedra/CDDLib.jl/actions?query=workflow%3ACI


### PR DESCRIPTION
We're removing this info from the JuMP docs, so it should be added here: https://github.com/jump-dev/JuMP.jl/pull/2578