### PR TITLE
More robust handling of error cases

### DIFF
--- a/src/CDDLib.jl
+++ b/src/CDDLib.jl
@@ -10,9 +10,45 @@ end
 
 using Polyhedra
 
+macro dd_ccall_pointer_error(f, args...)
+    quote
+        err = Ref{Cdd_ErrorType}(0)
+        ptr = ccall(($"dd_$f", libcddgmp), $(map(esc,args)...), err)
+        myerror($"dd_$f", ptr, err[])
+        ptr
+    end
+end
+
+macro dd_ccall_error(f, args...)
+    quote
+        err = Ref{Cdd_ErrorType}(0)
+        ret = ccall(($"dd_$f", libcddgmp), $(map(esc,args)...), err)
+        myerror($"dd_$f", err[])
+        ret
+    end
+end
+
 macro dd_ccall(f, args...)
     quote
         ret = ccall(($"dd_$f", libcddgmp), $(map(esc,args)...))
+        ret
+    end
+end
+
+macro ddf_ccall_pointer_error(f, args...)
+    quote
+        err = Ref{Cdd_ErrorType}(0)
+        ptr = ccall(($"ddf_$f", libcddgmp), $(map(esc,args)...), err)
+        myerror($"ddf_$f", ptr, err[])
+        ptr
+    end
+end
+
+macro ddf_ccall_error(f, args...)
+    quote
+        err = Ref{Cdd_ErrorType}(0)
+        ret = ccall(($"ddf_$f", libcddgmp), $(map(esc,args)...), err)
+        myerror($"ddf_$f", err[])
         ret
     end
 end

--- a/src/error.jl
+++ b/src/error.jl
@@ -18,10 +18,16 @@ const error_message = [
   "Numerically inconsistent",
 ]
 
-function myerror(err::Cdd_ErrorType)
+function myerror(func_name::String, err::Cdd_ErrorType)
     if err < 0 || err > 17
-        error("This should not happen, please report this bug")
+        error("$func_name gave an error code of $err which is out of the range of known error code. Pleasre report this by opening an issue at https://github.com/JuliaPolyhedra/CDDLib.jl.")
     elseif err < 17 # 17 means no error
-        error(error_message[err+1])
+        error(func_name, " : ", error_message[err+1])
+    end
+end
+function myerror(func_name::String, ptr::Ptr, err::Cdd_ErrorType)
+    myerror(func_name, err)
+    if ptr == C_NULL
+        error("$func_name returned a NULL pointer but did not provide any error. Please report this by opening an issue at https://github.com/JuliaPolyhedra/CDDLib.jl.")
     end
 end

--- a/src/lp.jl
+++ b/src/lp.jl
@@ -183,48 +183,62 @@ function myfree(lp::CDDLP)
 end
 
 function dd_matrix2feasibility(matrix::Ptr{Cdd_MatrixData{Cdouble}})
-    err = Ref{Cdd_ErrorType}(0)
-    lp = (@ddf_ccall Matrix2Feasibility Ptr{Cdd_LPData{Cdouble}} (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}) matrix err)
-    myerror(err[])
-    lp
+    return @ddf_ccall_pointer_error(
+        Matrix2Feasibility,
+        Ptr{Cdd_LPData{Cdouble}},
+        (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
 end
 function dd_matrix2feasibility(matrix::Ptr{Cdd_MatrixData{GMPRational}})
-    err = Ref{Cdd_ErrorType}(0)
-    lp = (@dd_ccall Matrix2Feasibility Ptr{Cdd_LPData{GMPRational}} (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}) matrix err)
-    myerror(err[])
-    lp
+    return @dd_ccall_pointer_error(
+        Matrix2Feasibility,
+        Ptr{Cdd_LPData{GMPRational}},
+        (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
 end
 function matrix2feasibility(matrix::CDDInequalityMatrix)
     CDDLP(dd_matrix2feasibility(matrix.matrix))
 end
 
 function dd_matrix2lp(matrix::Ptr{Cdd_MatrixData{Cdouble}})
-    err = Ref{Cdd_ErrorType}(0)
-    lp = (@ddf_ccall Matrix2LP Ptr{Cdd_LPData{Cdouble}} (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}) matrix err)
-    myerror(err[])
-    lp
+    return @ddf_ccall_pointer_error(
+        Matrix2LP,
+        Ptr{Cdd_LPData{Cdouble}},
+        (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
 end
 function dd_matrix2lp(matrix::Ptr{Cdd_MatrixData{GMPRational}})
-    err = Ref{Cdd_ErrorType}(0)
-    lp = (@dd_ccall Matrix2LP Ptr{Cdd_LPData{GMPRational}} (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}) matrix err)
-    myerror(err[])
-    lp
+    return @dd_ccall_pointer_error(
+        Matrix2LP,
+        Ptr{Cdd_LPData{GMPRational}},
+        (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
 end
 function matrix2lp(matrix::CDDInequalityMatrix)
     CDDLP(dd_matrix2lp(matrix.matrix))
 end
 
 function dd_lpsolve(lp::Ptr{Cdd_LPData{Cdouble}}, solver::Cdd_LPSolverType)
-    err = Ref{Cdd_ErrorType}(0)
-    found = (@ddf_ccall LPSolve Cdd_ErrorType (Ptr{Cdd_LPData{Cdouble}}, Cdd_LPSolverType, Ref{Cdd_ErrorType}) lp solver err)
-    myerror(err[])
-    found
+    return @ddf_ccall_error(
+        LPSolve,
+        Cdd_ErrorType,
+        (Ptr{Cdd_LPData{Cdouble}}, Cdd_LPSolverType, Ref{Cdd_ErrorType}),
+        lp,
+        solver,
+    )
 end
 function dd_lpsolve(lp::Ptr{Cdd_LPData{GMPRational}}, solver::Cdd_LPSolverType)
-    err = Ref{Cdd_ErrorType}(0)
-    found = (@dd_ccall LPSolve Cdd_ErrorType (Ptr{Cdd_LPData{GMPRational}}, Cdd_LPSolverType, Ref{Cdd_ErrorType}) lp solver err)
-    myerror(err[])
-    found
+    return @dd_ccall_error(
+        LPSolve,
+        Cdd_ErrorType,
+        (Ptr{Cdd_LPData{GMPRational}}, Cdd_LPSolverType, Ref{Cdd_ErrorType}),
+        lp,
+        solver,
+    )
 end
 function lpsolve(lp::CDDLP, solver::Symbol=:DualSimplex)
     found = dd_lpsolve(lp.lp, solver == :DualSimplex ? dd_DualSimplex : dd_CrissCross)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -1,8 +1,12 @@
 function dd_inputappend(poly::Ptr{Cdd_PolyhedraData{Cdouble}}, matrix::Ptr{Cdd_MatrixData{Cdouble}})
-    err = Ref{Cdd_ErrorType}(0)
     polyptr = Ref{Ptr{Cdd_PolyhedraData{Cdouble}}}(poly)
-    found = (@ddf_ccall DDInputAppend Cdd_boolean (Ref{Ptr{Cdd_PolyhedraData{Cdouble}}}, Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}) polyptr matrix err)
-    myerror(err[])
+    found = @ddf_ccall_error(
+        DDInputAppend,
+        Cdd_boolean,
+        (Ref{Ptr{Cdd_PolyhedraData{Cdouble}}}, Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
+        polyptr,
+        matrix,
+    )
     if !Bool(found)
         println("Double description not found")
     end
@@ -10,10 +14,14 @@ function dd_inputappend(poly::Ptr{Cdd_PolyhedraData{Cdouble}}, matrix::Ptr{Cdd_M
 end
 
 function dd_inputappend(poly::Ptr{Cdd_PolyhedraData{GMPRational}}, matrix::Ptr{Cdd_MatrixData{GMPRational}})
-    err = Ref{Cdd_ErrorType}(0)
     polyptr = Ref{Ptr{Cdd_PolyhedraData{GMPRational}}}(poly)
-    found = (@dd_ccall DDInputAppend Cdd_boolean (Ref{Ptr{Cdd_PolyhedraData{GMPRational}}}, Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}) polyptr matrix err)
-    myerror(err[])
+    found = @dd_ccall_error(
+        DDInputAppend,
+        Cdd_boolean,
+        (Ref{Ptr{Cdd_PolyhedraData{GMPRational}}}, Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
+        polyptr,
+        matrix,
+    )
     if !Bool(found)
         println("Double description not found") # FIXME
     end
@@ -56,17 +64,27 @@ end
 
 # Redundant
 function dd_redundant(matrix::Ptr{Cdd_MatrixData{Cdouble}}, i::Cdd_rowrange, len::Int)
-    err = Ref{Cdd_ErrorType}(0)
     certificate = Vector{Cdouble}(undef, len)
-    found = (@ddf_ccall Redundant Cdd_boolean (Ptr{Cdd_MatrixData{Cdouble}}, Cdd_rowrange, Ptr{Cdouble}, Ref{Cdd_ErrorType}) matrix  i certificate err)
-    myerror(err[])
+    found = @ddf_ccall_error(
+        Redundant,
+        Cdd_boolean,
+        (Ptr{Cdd_MatrixData{Cdouble}}, Cdd_rowrange, Ptr{Cdouble}, Ref{Cdd_ErrorType}),
+        matrix,
+        i,
+        certificate,
+    )
     (found, certificate)
 end
 function dd_redundant(matrix::Ptr{Cdd_MatrixData{GMPRational}}, i::Cdd_rowrange, len::Int)
-    err = Ref{Cdd_ErrorType}(0)
     certificateGMPRat = zeros(GMPRational, len)
-    found = (@dd_ccall Redundant Cdd_boolean (Ptr{Cdd_MatrixData{GMPRational}}, Cdd_rowrange, Ptr{GMPRational}, Ref{Cdd_ErrorType}) matrix i certificateGMPRat err)
-    myerror(err[])
+    found = @dd_ccall_error(
+        Redundant,
+        Cdd_boolean,
+        (Ptr{Cdd_MatrixData{GMPRational}}, Cdd_rowrange, Ptr{GMPRational}, Ref{Cdd_ErrorType}),
+        matrix,
+        i,
+        certificateGMPRat,
+    )
     certificate = Array{Rational{BigInt}}(certificateGMPRat)
     # myfree(certificateGMPRat)  # disabled due to https://github.com/JuliaPolyhedra/CDDLib.jl/issues/13
     (found, certificate)
@@ -85,16 +103,20 @@ end
 
 # Redundant rows
 function dd_redundantrows(matrix::Ptr{Cdd_MatrixData{Cdouble}})
-    err = Ref{Cdd_ErrorType}(0)
-    redundant_list = (@ddf_ccall RedundantRows Ptr{Culong} (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}) matrix err)
-    myerror(err[])
-    redundant_list
+    return @ddf_ccall_pointer_error(
+        RedundantRows,
+        Ptr{Culong},
+        (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
 end
 function dd_redundantrows(matrix::Ptr{Cdd_MatrixData{GMPRational}})
-    err = Ref{Cdd_ErrorType}(0)
-    redundant_list = (@dd_ccall RedundantRows Ptr{Culong} (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}) matrix err)
-    myerror(err[])
-    redundant_list
+    return @dd_ccall_pointer_error(
+        RedundantRows,
+        Ptr{Culong},
+        (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
 end
 function redundantrows(matrix::CDDMatrix)
     Base.convert(BitSet, CDDSet(dd_redundantrows(matrix.matrix), length(matrix)))
@@ -105,17 +127,27 @@ end
 
 # Strongly redundant
 function dd_sredundant(matrix::Ptr{Cdd_MatrixData{Cdouble}}, i::Cdd_rowrange, len::Int)
-    err = Ref{Cdd_ErrorType}(0)
     certificate = Vector{Cdouble1}(undef, len)
-    found = (@ddf_ccall SRedundant Cdd_boolean (Ptr{Cdd_MatrixData{Cdouble}}, Cdd_rowrange, Ptr{Cdouble}, Ref{Cdd_ErrorType}) matrix  i certificate err)
-    myerror(err[])
+    found = @ddf_ccall_error(
+        SRedundant,
+        Cdd_boolean,
+        (Ptr{Cdd_MatrixData{Cdouble}}, Cdd_rowrange, Ptr{Cdouble}, Ref{Cdd_ErrorType}),
+        matrix,
+        i,
+        certificate,
+    )
     (found, certificate)
 end
 function dd_sredundant(matrix::Ptr{Cdd_MatrixData{GMPRational}}, i::Cdd_rowrange, len::Int)
-    err = Ref{Cdd_ErrorType}(0)
     certificateGMPRat = zeros(GMPRational, len)
-    found = (@dd_ccall SRedundant Cdd_boolean (Ptr{Cdd_MatrixData{GMPRational}}, Cdd_rowrange, Ptr{GMPRational}, Ref{Cdd_ErrorType}) matrix i certificateGMPRat err)
-    myerror(err[])
+    found = @dd_ccall_error(
+        SRedundant,
+        Cdd_boolean,
+        (Ptr{Cdd_MatrixData{GMPRational}}, Cdd_rowrange, Ptr{GMPRational}, Ref{Cdd_ErrorType}),
+        matrix,
+        i,
+        certificateGMPRat,
+    )
     certificate = Array{Rational{BigInt}}(certificateGMPRat)
     # myfree(certificateGMPRat)  # disabled due to https://github.com/JuliaPolyhedra/CDDLib.jl/issues/13
     (found, certificate)
@@ -137,9 +169,15 @@ function dd_matrixcanonicalize(matrix::Ptr{Cdd_MatrixData{Cdouble}})
     impl_linset = Ref{Cdd_rowset}(0)
     redset = Ref{Cdd_rowset}(0)
     newpos = Ref{Cdd_rowindex}(0)
-    err = Ref{Cdd_ErrorType}(0)
-    found = (@ddf_ccall MatrixCanonicalize Cdd_boolean (Ref{Ptr{Cdd_MatrixData{Cdouble}}}, Ref{Cdd_rowset}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}) matptr impl_linset redset newpos err)
-    myerror(err[])
+    found = @ddf_ccall_error(
+        MatrixCanonicalize,
+        Cdd_boolean,
+        (Ref{Ptr{Cdd_MatrixData{Cdouble}}}, Ref{Cdd_rowset}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}),
+        matptr,
+        impl_linset,
+        redset,
+        newpos,
+    )
     (found, matptr[], impl_linset[], redset[], newpos[])
 end
 function dd_matrixcanonicalize(matrix::Ptr{Cdd_MatrixData{GMPRational}})
@@ -147,9 +185,15 @@ function dd_matrixcanonicalize(matrix::Ptr{Cdd_MatrixData{GMPRational}})
     impl_linset = Ref{Cdd_rowset}(0)
     redset = Ref{Cdd_rowset}(0)
     newpos = Ref{Cdd_rowindex}(0)
-    err = Ref{Cdd_ErrorType}(0)
-    found = (@dd_ccall MatrixCanonicalize Cdd_boolean (Ref{Ptr{Cdd_MatrixData{GMPRational}}}, Ref{Cdd_rowset}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}) matptr impl_linset redset newpos err)
-    myerror(err[])
+    found = @dd_ccall_error(
+        MatrixCanonicalize,
+        Cdd_boolean,
+        (Ref{Ptr{Cdd_MatrixData{GMPRational}}}, Ref{Cdd_rowset}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}),
+        matptr,
+        impl_linset,
+        redset,
+        newpos,
+    )
     (found, matptr[], impl_linset[], redset[], newpos[])
 end
 function canonicalize!(matrix::CDDMatrix)
@@ -166,9 +210,14 @@ function dd_matrixcanonicalizelinearity(matrix::Ptr{Cdd_MatrixData{Cdouble}})
     impl_linset = Ref{Cdd_rowset}(0)
     redset = Ref{Cdd_rowset}(0)
     newpos = Ref{Cdd_rowindex}(0)
-    err = Ref{Cdd_ErrorType}(0)
-    found = (@ddf_ccall MatrixCanonicalizeLinearity Cdd_boolean (Ref{Ptr{Cdd_MatrixData{Cdouble}}}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}) matptr impl_linset newpos err)
-    myerror(err[])
+    found = @ddf_ccall_error(
+        MatrixCanonicalizeLinearity,
+        Cdd_boolean,
+        (Ref{Ptr{Cdd_MatrixData{Cdouble}}}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}),
+        matptr,
+        impl_linset,
+        newpos,
+    )
     (found, matptr[], impl_linset[], newpos[])
 end
 function dd_matrixcanonicalizelinearity(matrix::Ptr{Cdd_MatrixData{GMPRational}})
@@ -176,9 +225,14 @@ function dd_matrixcanonicalizelinearity(matrix::Ptr{Cdd_MatrixData{GMPRational}}
     impl_linset = Ref{Cdd_rowset}(0)
     redset = Ref{Cdd_rowset}(0)
     newpos = Ref{Cdd_rowindex}(0)
-    err = Ref{Cdd_ErrorType}(0)
-    found = (@dd_ccall MatrixCanonicalizeLinearity Cdd_boolean (Ref{Ptr{Cdd_MatrixData{GMPRational}}}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}) matptr impl_linset newpos err)
-    myerror(err[])
+    found = @dd_ccall_error(
+        MatrixCanonicalizeLinearity,
+        Cdd_boolean,
+        (Ref{Ptr{Cdd_MatrixData{GMPRational}}}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}),
+        matptr,
+        impl_linset,
+        newpos,
+    )
     (found, matptr[], impl_linset[], newpos[])
 end
 function canonicalizelinearity!(matrix::CDDMatrix)
@@ -193,18 +247,28 @@ function dd_matrixredundancyremove(matrix::Ptr{Cdd_MatrixData{Cdouble}})
     matptr = Ref{Ptr{Cdd_MatrixData{Cdouble}}}(matrix)
     redset = Ref{Cdd_rowset}(0)
     newpos = Ref{Cdd_rowindex}(0)
-    err = Ref{Cdd_ErrorType}(0)
-    found = (@ddf_ccall MatrixRedundancyRemove Cdd_boolean (Ref{Ptr{Cdd_MatrixData{Cdouble}}}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}) matptr redset newpos err)
-    myerror(err[])
+    found = @ddf_ccall_error(
+        MatrixRedundancyRemove,
+        Cdd_boolean,
+        (Ref{Ptr{Cdd_MatrixData{Cdouble}}}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}),
+        matptr,
+        redset,
+        newpos,
+    )
     (found, matptr[], redset[], newpos[])
 end
 function dd_matrixredundancyremove(matrix::Ptr{Cdd_MatrixData{GMPRational}})
     matptr = Ref{Ptr{Cdd_MatrixData{GMPRational}}}(matrix)
     redset = Ref{Cdd_rowset}(0)
     newpos = Ref{Cdd_rowindex}(0)
-    err = Ref{Cdd_ErrorType}(0)
-    found = (@dd_ccall MatrixRedundancyRemove Cdd_boolean (Ref{Ptr{Cdd_MatrixData{GMPRational}}}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}) matptr redset newpos err)
-    myerror(err[])
+    found = @dd_ccall_error(
+        MatrixRedundancyRemove,
+        Cdd_boolean,
+        (Ref{Ptr{Cdd_MatrixData{GMPRational}}}, Ref{Cdd_rowset}, Ref{Cdd_rowindex}, Ref{Cdd_ErrorType}),
+        matptr,
+        redset,
+        newpos,
+    )
     (found, matptr[], redset[], newpos[])
 end
 function redundancyremove!(matrix::CDDMatrix)
@@ -218,15 +282,20 @@ end
 # Fourier Elimination
 
 function dd_fourierelimination(matrix::Ptr{Cdd_MatrixData{Cdouble}})
-    err = Ref{Cdd_ErrorType}(0)
-    newmatrix = (@ddf_ccall FourierElimination Ptr{Cdd_MatrixData{Cdouble}} (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}) matrix err)
-    myerror(err[])
-    newmatrix
+    return @ddf_ccall_pointer_error(
+        FourierElimination,
+        Ptr{Cdd_MatrixData{Cdouble}},
+        (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
 end
 function dd_fourierelimination(matrix::Ptr{Cdd_MatrixData{GMPRational}})
-    err = Ref{Cdd_ErrorType}(0)
-    newmatrix = (@dd_ccall FourierElimination Ptr{Cdd_MatrixData{GMPRational}} (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}) matrix err)
-    myerror(err[])
+    return @dd_ccall_pointer_error(
+        FourierElimination,
+        Ptr{Cdd_MatrixData{GMPRational}},
+        (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
     newmatrix
 end
 function fourierelimination(matrix::CDDInequalityMatrix{T, S}) where {T, S}
@@ -239,16 +308,22 @@ end
 # Block Elimination
 
 function dd_blockelimination(matrix::Ptr{Cdd_MatrixData{Cdouble}}, delset::Cdd_colset)
-    err = Ref{Cdd_ErrorType}(0)
-    newmatrix = (@ddf_ccall BlockElimination Ptr{Cdd_MatrixData{Cdouble}} (Ptr{Cdd_MatrixData{Cdouble}}, Cdd_colset, Ref{Cdd_ErrorType}) matrix delset err)
-    myerror(err[])
-    newmatrix
+    return @ddf_ccall_pointer_error(
+        BlockElimination,
+        Ptr{Cdd_MatrixData{Cdouble}},
+        (Ptr{Cdd_MatrixData{Cdouble}}, Cdd_colset, Ref{Cdd_ErrorType}),
+        matrix,
+        delset,
+    )
 end
 function dd_blockelimination(matrix::Ptr{Cdd_MatrixData{GMPRational}}, delset::Cdd_colset)
-    err = Ref{Cdd_ErrorType}(0)
-    newmatrix = (@dd_ccall BlockElimination Ptr{Cdd_MatrixData{GMPRational}} (Ptr{Cdd_MatrixData{GMPRational}}, Cdd_colset, Ref{Cdd_ErrorType}) matrix delset err)
-    myerror(err[])
-    newmatrix
+    return @dd_ccall_pointer_error(
+        BlockElimination,
+        Ptr{Cdd_MatrixData{GMPRational}},
+        (Ptr{Cdd_MatrixData{GMPRational}}, Cdd_colset, Ref{Cdd_ErrorType}),
+        matrix,
+        delset,
+    )
 end
 function blockelimination(matrix::CDDInequalityMatrix{T, S}, delset=BitSet([fulldim(matrix)])) where {T, S}
     if last(delset) > fulldim(matrix)

--- a/src/polyhedra.jl
+++ b/src/polyhedra.jl
@@ -48,16 +48,20 @@ mutable struct Cdd_PolyhedraData{T<:MyType}
 end
 
 function dd_matrix2poly(matrix::Ptr{Cdd_MatrixData{Cdouble}})
-    err = Ref{Cdd_ErrorType}(0)
-    poly = @ddf_ccall DDMatrix2Poly Ptr{Cdd_PolyhedraData{Cdouble}} (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}) matrix err
-    myerror(err[])
-    poly
+    return @ddf_ccall_pointer_error(
+        DDMatrix2Poly,
+        Ptr{Cdd_PolyhedraData{Cdouble}},
+        (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
 end
 function dd_matrix2poly(matrix::Ptr{Cdd_MatrixData{GMPRational}})
-    err = Ref{Cdd_ErrorType}(0)
-    poly = @dd_ccall DDMatrix2Poly Ptr{Cdd_PolyhedraData{GMPRational}} (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}) matrix err
-    myerror(err[])
-    poly
+    return @dd_ccall_pointer_error(
+        DDMatrix2Poly,
+        Ptr{Cdd_PolyhedraData{GMPRational}},
+        (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
 end
 
 mutable struct CDDPolyhedra{T<:PolyType, S}


### PR DESCRIPTION
For functions returning a pointer, checks whether the pointer is `NULL` in addition to checking whether cddlib returned any error message.