### PR TITLE
Wrap dd_Matrix2Adjacency

### DIFF
--- a/src/operations.jl
+++ b/src/operations.jl
@@ -378,4 +378,4 @@ function blockelimination(ine::HRepresentation, delset=BitSet([fulldim(ine)]))
     blockelimination(Base.convert(CDDInequalityMatrix, ine), delset)
 end
 
-export redundant, redundantrows, sredundant, fourierelimination, blockelimination, canonicalize!, redundancyremove!
+export redundant, redundantrows, sredundant, matrix2adjacency, fourierelimination, blockelimination, canonicalize!, redundancyremove!

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -62,6 +62,26 @@ function matrixappend(matrix::CDDMatrix{T}, repr::Representation{S}) where {S, T
     matrixappend(matrix, cddmatrix(T, repr))
 end
 
+function dd_matrix2adjacency(matrix::Ptr{Cdd_MatrixData{Cdouble}})
+    return @ddf_ccall_pointer_error(
+        Matrix2Adjacency,
+        Ptr{SetFamily},
+        (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
+end
+function dd_matrix2adjacency(matrix::Ptr{Cdd_MatrixData{GMPRational}})
+    return @dd_ccall_pointer_error(
+        Matrix2Adjacency,
+        Ptr{SetFamily},
+        (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
+end
+function matrix2adjacency(matrix::CDDMatrix)
+    return convert_free(Vector{BitSet}, dd_matrix2adjacency(matrix.matrix))
+end
+
 # Redundant
 function dd_redundant(matrix::Ptr{Cdd_MatrixData{Cdouble}}, i::Cdd_rowrange, len::Int)
     certificate = Vector{Cdouble}(undef, len)
@@ -139,7 +159,7 @@ function dd_redundantrows(matrix::Ptr{Cdd_MatrixData{GMPRational}}; via_shooting
 end
 
 function redundantrows(matrix::CDDMatrix; kws...)
-    Base.convert(BitSet, CDDSet(dd_redundantrows(matrix.matrix; kws...), length(matrix)))
+    convert_free(BitSet, CDDSet(dd_redundantrows(matrix.matrix; kws...), length(matrix)))
 end
 
 function redundantrows(repr::Representation; kws...)

--- a/test/adjacency.jl
+++ b/test/adjacency.jl
@@ -1,0 +1,15 @@
+using Test
+using Polyhedra
+using CDDLib
+
+@testset "Adjacency $precision" for precision in [:float, :exact]
+    vsquare = vrep([[i, j] for i in [-1, 1] for j in [-1, 1]])
+    p = polyhedron(vsquare, CDDLib.Library(precision))
+    @test p isa CDDLib.Polyhedron{precision == :float ? Float64 : Rational{BigInt}}
+    @test matrix2adjacency(p.ext) == [
+        BitSet([2, 3])
+        BitSet([1, 4])
+        BitSet([1, 4])
+        BitSet([2, 3])
+    ]
+end

--- a/test/redundant.jl
+++ b/test/redundant.jl
@@ -7,11 +7,13 @@ using CDDLib
         lib = CDDLib.Library(precision)
         V = [3 0; 1 1; 0 3; 0 0]
         p = polyhedron(vrep(V), lib)
+        @test p isa CDDLib.Polyhedron{precision == :float ? Float64 : Rational{BigInt}}
         @test collect(CDDLib.getvredundantindices(p; via_shooting)) == [2]
 
         A = [1 0; 1 1; 0 1; -1 0; 0 -1]
         b = [1, 2, 1, 1, 1]
         p = polyhedron(hrep(A, b), lib)
+        @test p isa CDDLib.Polyhedron{precision == :float ? Float64 : Rational{BigInt}}
         @test collect(CDDLib.gethredundantindices(p; via_shooting)) == [2]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ lpsolver = tuple()
 
 include("utils.jl")
 include("redundant.jl")
+include("adjacency.jl")
 include("simplex.jl")
 include("permutahedron.jl")
 include("board.jl")


### PR DESCRIPTION
There is no Polyhedra.jl interface for that yet so currently, it's just:
```julia
julia> using CDDLib, Polyhedra

julia> vsquare = vrep([[i, j] for i in [-1, 1] for j in [-1, 1]])
V-representation Polyhedra.PointsHull{Int64, Vector{Int64}, Int64}:
4-element iterator of Vector{Int64}:
 [-1, -1]
 [-1, 1]
 [1, -1]
 [1, 1]

julia> p = polyhedron(vsquare, CDDLib.Library())
Polyhedron CDDLib.Polyhedron{Float64}:
4-element iterator of Vector{Float64}:
 [-1.0, -1.0]
 [-1.0, 1.0]
 [1.0, -1.0]
 [1.0, 1.0]

julia> matrix2adjacency(p.ext)
4-element Vector{BitSet}:
 BitSet([2, 3])
 BitSet([1, 4])
 BitSet([1, 4])
 BitSet([2, 3])
```

Closes https://github.com/JuliaPolyhedra/CDDLib.jl/issues/71