### PR TITLE
Add support for RedundantRowsViaShooting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,26 +43,18 @@ jobs:
             os: windows-latest
             arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
           depwarn: error
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/ccall.jl
+++ b/src/ccall.jl
@@ -1,6 +1,8 @@
 macro dd_ccall_pointer_error(f, args...)
     quote
-        err = Ref{Cdd_ErrorType}(0)
+        # RedundantRowsViaShooting don't modify the error code so
+        # we need to set it with an initial value that means no error
+        err = Ref{Cdd_ErrorType}(length(error_message))
         ptr = ccall(($"dd_$f", libcddgmp), $(map(esc,args)...), err)
         myerror($"dd_$f", ptr, err[])
         ptr
@@ -9,7 +11,9 @@ end
 
 macro dd_ccall_error(f, args...)
     quote
-        err = Ref{Cdd_ErrorType}(0)
+        # RedundantRowsViaShooting don't modify the error code so
+        # we need to set it with an initial value that means no error
+        err = Ref{Cdd_ErrorType}(length(error_message))
         ret = ccall(($"dd_$f", libcddgmp), $(map(esc,args)...), err)
         myerror($"dd_$f", err[])
         ret
@@ -25,7 +29,9 @@ end
 
 macro ddf_ccall_pointer_error(f, args...)
     quote
-        err = Ref{Cdd_ErrorType}(0)
+        # RedundantRowsViaShooting don't modify the error code so
+        # we need to set it with an initial value that means no error
+        err = Ref{Cdd_ErrorType}(length(error_message))
         ptr = ccall(($"ddf_$f", libcddgmp), $(map(esc,args)...), err)
         myerror($"ddf_$f", ptr, err[])
         ptr
@@ -34,7 +40,9 @@ end
 
 macro ddf_ccall_error(f, args...)
     quote
-        err = Ref{Cdd_ErrorType}(0)
+        # RedundantRowsViaShooting don't modify the error code so
+        # we need to set it with an initial value that means no error
+        err = Ref{Cdd_ErrorType}(length(error_message))
         ret = ccall(($"ddf_$f", libcddgmp), $(map(esc,args)...), err)
         myerror($"ddf_$f", err[])
         ret

--- a/src/error.jl
+++ b/src/error.jl
@@ -19,10 +19,11 @@ const error_message = [
 ]
 
 function myerror(func_name::String, err::Cdd_ErrorType)
-    if err < 0 || err > 17
-        error("$func_name gave an error code of $err which is out of the range of known error code. Pleasre report this by opening an issue at https://github.com/JuliaPolyhedra/CDDLib.jl.")
-    elseif err < 17 # 17 means no error
+    idx = err + 1
+    if idx in eachindex(error_message)
         error(func_name, " : ", error_message[err+1])
+    elseif err != length(error_message) # 17 means no error
+        error("$func_name gave an error code of $err which is out of the range of known error code. Pleasre report this by opening an issue at https://github.com/JuliaPolyhedra/CDDLib.jl.")
     end
 end
 function myerror(func_name::String, ptr::Ptr, err::Cdd_ErrorType)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -125,6 +125,27 @@ function redundantrows(repr::Representation)
     redundantrows(CDDMatrix(repr))
 end
 
+function dd_redundant_rows_via_shooting(matrix::Ptr{Cdd_MatrixData{Cdouble}})
+    return @ddf_ccall_pointer_error(
+        RedundantRowsViaShooting,
+        Ptr{Culong},
+        (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
+end
+function dd_redundant_rows_via_shooting(matrix::Ptr{Cdd_MatrixData{GMPRational}})
+    return @dd_ccall_pointer_error(
+        RedundantRowsViaShooting,
+        Ptr{Culong},
+        (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
+        matrix,
+    )
+end
+function redundant_rows_via_shooting(matrix::CDDMatrix)
+    Base.convert(BitSet, CDDSet(dd_redundant_rows_via_shooting(matrix.matrix), length(matrix)))
+end
+
+
 # Strongly redundant
 function dd_sredundant(matrix::Ptr{Cdd_MatrixData{Cdouble}}, i::Cdd_rowrange, len::Int)
     certificate = Vector{Cdouble1}(undef, len)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -102,49 +102,49 @@ function redundant(repr::Representation, i::Integer)
 end
 
 # Redundant rows
-function dd_redundantrows(matrix::Ptr{Cdd_MatrixData{Cdouble}})
-    return @ddf_ccall_pointer_error(
-        RedundantRows,
-        Ptr{Culong},
-        (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
-        matrix,
-    )
-end
-function dd_redundantrows(matrix::Ptr{Cdd_MatrixData{GMPRational}})
-    return @dd_ccall_pointer_error(
-        RedundantRows,
-        Ptr{Culong},
-        (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
-        matrix,
-    )
-end
-function redundantrows(matrix::CDDMatrix)
-    Base.convert(BitSet, CDDSet(dd_redundantrows(matrix.matrix), length(matrix)))
-end
-function redundantrows(repr::Representation)
-    redundantrows(CDDMatrix(repr))
+function dd_redundantrows(matrix::Ptr{Cdd_MatrixData{Cdouble}}; via_shooting::Bool = false)
+    if via_shooting
+        return @ddf_ccall_pointer_error(
+            RedundantRowsViaShooting,
+            Ptr{Culong},
+            (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
+            matrix,
+        )
+    else
+        return @ddf_ccall_pointer_error(
+            RedundantRows,
+            Ptr{Culong},
+            (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
+            matrix,
+        )
+    end
 end
 
-function dd_redundant_rows_via_shooting(matrix::Ptr{Cdd_MatrixData{Cdouble}})
-    return @ddf_ccall_pointer_error(
-        RedundantRowsViaShooting,
-        Ptr{Culong},
-        (Ptr{Cdd_MatrixData{Cdouble}}, Ref{Cdd_ErrorType}),
-        matrix,
-    )
-end
-function dd_redundant_rows_via_shooting(matrix::Ptr{Cdd_MatrixData{GMPRational}})
-    return @dd_ccall_pointer_error(
-        RedundantRowsViaShooting,
-        Ptr{Culong},
-        (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
-        matrix,
-    )
-end
-function redundant_rows_via_shooting(matrix::CDDMatrix)
-    Base.convert(BitSet, CDDSet(dd_redundant_rows_via_shooting(matrix.matrix), length(matrix)))
+function dd_redundantrows(matrix::Ptr{Cdd_MatrixData{GMPRational}}; via_shooting::Bool = false)
+    if via_shooting
+        return @dd_ccall_pointer_error(
+            RedundantRowsViaShooting,
+            Ptr{Culong},
+            (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
+            matrix,
+        )
+    else
+        return @dd_ccall_pointer_error(
+            RedundantRows,
+            Ptr{Culong},
+            (Ptr{Cdd_MatrixData{GMPRational}}, Ref{Cdd_ErrorType}),
+            matrix,
+        )
+    end
 end
 
+function redundantrows(matrix::CDDMatrix; kws...)
+    Base.convert(BitSet, CDDSet(dd_redundantrows(matrix.matrix; kws...), length(matrix)))
+end
+
+function redundantrows(repr::Representation; kws...)
+    redundantrows(CDDMatrix(repr); kws...)
+end
 
 # Strongly redundant
 function dd_sredundant(matrix::Ptr{Cdd_MatrixData{Cdouble}}, i::Cdd_rowrange, len::Int)

--- a/src/polyhedron.jl
+++ b/src/polyhedron.jl
@@ -290,19 +290,11 @@ function Base.isempty(p::Polyhedron)
     return MOI.get(copylpsolution(lp), MOI.TerminationStatus()) != MOI.OPTIMAL
 end
 
-function gethredundantindices(p::Polyhedron; via_shooting::Bool = false)
-    if via_shooting
-        redundantrows(getine(p))
-    else
-        redundant_rows_via_shooting(getine(p))
-    end
+function gethredundantindices(p::Polyhedron; kws...)
+    redundantrows(getine(p); kws...)
 end
-function getvredundantindices(p::Polyhedron; via_shooting::Bool = false)
-    if via_shooting
-        redundantrows(getext(p))
-    else
-        redundant_rows_via_shooting(getext(p))
-    end
+function getvredundantindices(p::Polyhedron; kws...)
+    redundantrows(getext(p); kws...)
 end
 
 # type CDDLPPolyhedron{T} <: LPPolyhedron{T}

--- a/src/polyhedron.jl
+++ b/src/polyhedron.jl
@@ -290,11 +290,19 @@ function Base.isempty(p::Polyhedron)
     return MOI.get(copylpsolution(lp), MOI.TerminationStatus()) != MOI.OPTIMAL
 end
 
-function gethredundantindices(p::Polyhedron)
-    redundantrows(getine(p))
+function gethredundantindices(p::Polyhedron; via_shooting::Bool = false)
+    if via_shooting
+        redundantrows(getine(p))
+    else
+        redundant_rows_via_shooting(getine(p))
+    end
 end
-function getvredundantindices(p::Polyhedron)
-    redundantrows(getext(p))
+function getvredundantindices(p::Polyhedron; via_shooting::Bool = false)
+    if via_shooting
+        redundantrows(getext(p))
+    else
+        redundant_rows_via_shooting(getext(p))
+    end
 end
 
 # type CDDLPPolyhedron{T} <: LPPolyhedron{T}

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CDDLib = "3391f64e-dcde-5f30-b752-e11513730f60"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -8,3 +8,12 @@ end
 @testset "Infinite $x" for x in [1 // 0, -2 // 0, NaN, Inf, -Inf]
     _invalid(x)
 end
+
+@testset "myerror" begin
+    err = ErrorException("A : Dimension too large")
+    @test_throws err CDDLib.myerror("A", CDDLib.Cdd_ErrorType(0))
+    err = ErrorException("A gave an error code of 18 which is out of the range of known error code. Pleasre report this by opening an issue at https://github.com/JuliaPolyhedra/CDDLib.jl.")
+    @test_throws err CDDLib.myerror("A", CDDLib.Cdd_ErrorType(18))
+    err = ErrorException("A gave an error code of -1 which is out of the range of known error code. Pleasre report this by opening an issue at https://github.com/JuliaPolyhedra/CDDLib.jl.")
+    @test_throws err CDDLib.myerror("A", CDDLib.Cdd_ErrorType(-1))
+end

--- a/test/redundant.jl
+++ b/test/redundant.jl
@@ -10,8 +10,8 @@ using CDDLib
         @test collect(CDDLib.getvredundantindices(p; via_shooting)) == [2]
 
         A = [1 0; 1 1; 0 1; -1 0; 0 -1]
-        b = [1, 2, 1, -1, -1]
+        b = [1, 2, 1, 1, 1]
         p = polyhedron(hrep(A, b), lib)
-        @test collect(CDDLib.gethredundantindices(p; via_shooting)) == [1, 3]
+        @test collect(CDDLib.gethredundantindices(p; via_shooting)) == [2]
     end
 end

--- a/test/redundant.jl
+++ b/test/redundant.jl
@@ -1,0 +1,15 @@
+using Test
+using Polyhedra
+using CDDLib
+
+@testset "Redundant test $precision" for precision in [:float, :exact]
+    lib = CDDLib.Library(precision)
+    V = [3 0; 1 1; 0 3; 0 0]
+    p = polyhedron(vrep(V), lib)
+    @show CDDLib.getvredundantindices(p)
+
+    A = [1 0; 1 1; 0 1; -1 0; 0 -1]
+    b = [1, 2, 1, -1, -1]
+    p = polyhedron(hrep(A, b, ls), lib)
+    @show CDDLib.gethredundantindices(p)
+end

--- a/test/redundant.jl
+++ b/test/redundant.jl
@@ -2,14 +2,16 @@ using Test
 using Polyhedra
 using CDDLib
 
-@testset "Redundant test $precision" for precision in [:float, :exact]
-    lib = CDDLib.Library(precision)
-    V = [3 0; 1 1; 0 3; 0 0]
-    p = polyhedron(vrep(V), lib)
-    @show CDDLib.getvredundantindices(p)
+@testset "Via shooting $(via_shooting)" for via_shooting in [false, true]
+    @testset "Redundant test $precision" for precision in [:float, :exact]
+        lib = CDDLib.Library(precision)
+        V = [3 0; 1 1; 0 3; 0 0]
+        p = polyhedron(vrep(V), lib)
+        @test collect(CDDLib.getvredundantindices(p; via_shooting)) == [2]
 
-    A = [1 0; 1 1; 0 1; -1 0; 0 -1]
-    b = [1, 2, 1, -1, -1]
-    p = polyhedron(hrep(A, b, ls), lib)
-    @show CDDLib.gethredundantindices(p)
+        A = [1 0; 1 1; 0 1; -1 0; 0 -1]
+        b = [1, 2, 1, -1, -1]
+        p = polyhedron(hrep(A, b), lib)
+        @test collect(CDDLib.gethredundantindices(p; via_shooting)) == [1, 3]
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using JuMP
 lpsolver = tuple()
 
 include("utils.jl")
+include("redundant.jl")
 include("simplex.jl")
 include("permutahedron.jl")
 include("board.jl")


### PR DESCRIPTION
I get
```
in expression starting at /home/blegat/.julia/dev/CDDLib/test/redundant.jl:5

julia> include("redundant.jl");
Redundant test float: Error During Test at /home/blegat/.julia/dev/CDDLib/test/redundant.jl:5
  Got exception outside of a @test
  ddf_RedundantRowsViaShooting : Dimension too large
  Stacktrace:
    [1] error(::String, ::String, ::String)
      @ Base ./error.jl:44
    [2] myerror
      @ ~/.julia/dev/CDDLib/src/error.jl:25 [inlined]
    [3] myerror
      @ ~/.julia/dev/CDDLib/src/error.jl:29 [inlined]
    [4] macro expansion
      @ ~/.julia/dev/CDDLib/src/ccall.jl:30 [inlined]
    [5] dd_redundant_rows_via_shooting(matrix::Ptr{CDDLib.Cdd_MatrixData{Float64}})
      @ CDDLib ~/.julia/dev/CDDLib/src/operations.jl:129
```
**EDIT** Should be fixed now

Closes https://github.com/JuliaPolyhedra/CDDLib.jl/issues/92